### PR TITLE
Add Ganymede customizations

### DIFF
--- a/fish/.config/fish/functions/gi.fish
+++ b/fish/.config/fish/functions/gi.fish
@@ -1,0 +1,3 @@
+function gi
+	curl -L -s https://www.gitignore.io/api/$argv
+end

--- a/misc/.profile
+++ b/misc/.profile
@@ -14,3 +14,6 @@ export MUSIC_PLAYER="google-music.sh"
 export VIRTUALIZATION="virt-manager"
 
 export PATH=$PATH:~/.local/bin/:
+
+# Avoid errors about the accessibility bus
+export NO_AT_BRIDGE=1

--- a/polybar/.config/polybar/config
+++ b/polybar/.config/polybar/config
@@ -63,9 +63,9 @@ scroll-down = bspwm-deskprev
 enable-ipc = true
 
 [bar/ganymede-primary]
-monitor = ${env:MONITOR:HDMI-1}
+monitor = ${env:MONITOR:DVI-D-0}
 width = 100%
-height = 22
+height = 24
 offset-x = 0
 offset-y = 0
 
@@ -97,6 +97,8 @@ modules-right = mpd volume ganymede-network cpu memory temperature date powermen
 
 tray-position = right
 tray-padding = 2
+#tray-transparent = true
+#tray-background = #0063ff
 
 wm-restack = bspwm
 
@@ -106,9 +108,9 @@ scroll-down = bspwm-deskprev
 enable-ipc = true
 
 [bar/ganymede-secondary]
-monitor = ${env:MONITOR:DVI-I-1}
+monitor = ${env:MONITOR:HDMI-0}
 width = 100%
-height = 22
+height = 24
 offset-x = 0
 offset-y = 0
 
@@ -138,8 +140,10 @@ modules-left = bspwm xwindow
 modules-center =
 modules-right = filesystem
 
-tray-position = right
-tray-padding = 2
+#tray-position = right
+#tray-padding = 2
+#tray-transparent = true
+#tray-background = #0063ff
 
 wm-restack = bspwm
 
@@ -319,7 +323,7 @@ ramp-signal-foreground = ${colors.foreground-alt}
 
 [module/ganymede-network]
 type = internal/network
-interface =
+interface = enp0s31f6
 interval = 3.0
 accumulate-stats = true
 

--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -24,8 +24,6 @@ Plug 'tpope/vim-unimpaired'
 Plug 'tpope/vim-vinegar'
 Plug 'vim-airline/vim-airline'
 Plug 'vim-airline/vim-airline-themes'
-Plug 'xolox/vim-misc'
-Plug 'xolox/vim-notes'
 Plug 'IrishPrime/WhiteWash.vim'
 " Vim-Scripts repos
 Plug 'vim-scripts/hexHighlight.vim'
@@ -123,6 +121,14 @@ if has("autocmd")
 	autocmd BufNewFile *.py     0r $HOME/Templates/Python.py
 	autocmd BufNewFile *.*htm*  0r $HOME/Templates/XHTML.xhtml
 	autocmd BufNewFile Makefile 0r $HOME/Templates/Makefile
+	" autocmd BufNewFile,BufRead {*.pl,*.pm,*.t} setlocal foldexpr=getline(v:lnum)=~'^=cut'?'<1':getline(v:lnum)=~'^='?'1':'=' |
+	" autocmd BufNewFile,BufRead {*.pl,*.pm,*.t} setlocal foldmethod=expr
+
+	augroup vimrc-incsearch-highlight
+		autocmd!
+		autocmd CmdlineEnter /,\? :set hlsearch
+		autocmd CmdlineLeave /,\? :set nohlsearch
+	augroup END
 endif
 " }}}
 
@@ -280,25 +286,21 @@ let g:airline_symbols.linenr = ''
 " }}}
 
 " CtrlP {{{
-let g:ctrlp_root_markers = ['cscope.out']
 let g:ctrlp_by_filename = 1
-let g:ctrlp_regexp = 1
+let g:ctrlp_extensions = ['tag', 'quickfix', 'undo', 'line', 'changes', 'mixed']
 let g:ctrlp_open_multiple_files = '1rjv'
-" }}}
-
-" Notes.vim {{{
-let g:notes_directories = ['~/Documents/Notes']
-let g:notes_suffix = '.txt'
-let g:notes_title_sync = 'rename_file'
+let g:ctrlp_regexp = 1
+let g:ctrlp_root_markers = ['cscope.out']
 " }}}
 
 " The Silver Searcher {{{
 if executable('ag')
 	" Use ag over grep
-	set grepprg=ag\ --nogroup\ --nocolor
+	set grepprg=ag\ --nogroup\ --nocolor\ --column
+	set grepformat=%f:%l:%c%m
 
 	" Use ag in CtrlP
-	let g:ctrlp_user_command = 'ag %s -l --nocolor --hidden -g ""'
+	let g:ctrlp_user_command = 'ag %s -l --nocolor --hidden --ignore .git -g ""'
 
 	" Skip caching since ag is so fast
 	let g:ctrlp_use_caching = 0
@@ -319,13 +321,14 @@ let g:syntastic_enable_perl_checker = 1
 " }}}
 
 " Colorscheme
+" https://github.com/lifepillar/vim-solarized8
 if has('termguicolors') && ($STY != '')
 	set termguicolors
 endif
 
 " set Vim-specific sequences for RGB colors
-" let &t_8f = "\<Esc>[38;2;%lu;%lu;%lum"
-" let &t_8b = "\<Esc>[48;2;%lu;%lu;%lum"
+let &t_8f = '\<Esc>[38;2;%lu;%lu;%lum'
+let &t_8b = '\<Esc>[48;2;%lu;%lu;%lum'
 let g:solarized_termtrans = 1
 let g:solarized_use16 = 1
 colorscheme solarized8


### PR DESCRIPTION
- Add `gi` command to `fish` to generate `.gitignore` files with
  `gitignore.io`.
- Set environment variable to prevent accessibility bus errors.
- Correct monitor names and network device names in `polybar` for
  `ganymede` bars.
- Remove `Notes.vim`.
- Enable `ctrlp.vim` extensions.
- Resolves #8.